### PR TITLE
Fixed typos

### DIFF
--- a/Samples-Http/Java/TTSSample/src/com/microsoft/cognitiveservices/ttssample/TTSSample.java
+++ b/Samples-Http/Java/TTSSample/src/com/microsoft/cognitiveservices/ttssample/TTSSample.java
@@ -45,7 +45,7 @@ import javax.sound.sampled.SourceDataLine;
 public class TTSSample {
 
 	public static void main(String[] args) {
-		String textToSynthesize = "This is a demo to call microsoft text to speach service in java.";
+		String textToSynthesize = "This is a demo to call microsoft text to speech service in java.";
 		String outputFormat = AudioOutputFormat.Riff16Khz16BitMonoPcm;
         String deviceLanguage = "en-US";
         String genderName = Gender.Female;

--- a/Samples-Http/NodeJS/TTSService.js
+++ b/Samples-Http/NodeJS/TTSService.js
@@ -55,7 +55,7 @@ var util = require('util'),
 	};
 
 	var SsmlTemplate = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='%s' xml:gender='%s' name='%s'>%s</voice></speak>";
-	var post_speak_data = util.format(SsmlTemplate, 'en-US', 'Female', 'Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)', 'This is a demo to call microsoft text to speach service in javascript.');
+	var post_speak_data = util.format(SsmlTemplate, 'en-US', 'Female', 'Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)', 'This is a demo to call microsoft text to speech service in javascript.');
 	
 	post_option.headers = {
 		'content-type' : 'application/ssml+xml',

--- a/Samples-Http/PHP/TTSService.php
+++ b/Samples-Http/PHP/TTSService.php
@@ -43,7 +43,7 @@ else{
    $ttsServiceUri = "https://speech.platform.bing.com:443/synthesize";
 
    //$SsmlTemplate = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='%s' xml:gender='%s' name='%s'>%s</voice></speak>";
-   $data = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='en-US' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)'>This is a demo to call microsoft text to speach service in php.</voice></speak>";
+   $data = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='en-US' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)'>This is a demo to call microsoft text to speech service in php.</voice></speak>";
    echo "tts post data: ". $data . "<br>";
    $options = array(
     'http' => array(

--- a/Samples-Http/Python/TTSSample.py
+++ b/Samples-Http/Python/TTSSample.py
@@ -33,7 +33,7 @@ conn.close()
 accesstoken = data.decode("UTF-8")
 print ("Access Token: " + accesstoken)
 
-body = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='en-us' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)'>This is a demo to call microsoft text to speach service in python.</voice></speak>"
+body = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='en-us' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)'>This is a demo to call microsoft text to speech service in python.</voice></speak>"
 
 headers = {"Content-type": "application/ssml+xml", 
 			"X-Microsoft-OutputFormat": "riff-16khz-16bit-mono-pcm", 

--- a/Samples-Http/Ruby/TTSSample.rb
+++ b/Samples-Http/Ruby/TTSSample.rb
@@ -53,7 +53,7 @@ headers = {
 }
 
 # SsmlTemplate = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='%s' xml:gender='%s' name='%s'>%s</voice></speak>"
-data = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='en-US' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)'>This is a demo to call microsoft text to speach service in php.</voice></speak>"
+data = "<speak version='1.0' xml:lang='en-us'><voice xml:lang='en-US' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)'>This is a demo to call microsoft text to speech service in ruby.</voice></speak>"
 
 # get the wave data
 puts "get the wave data"


### PR DESCRIPTION
'Speach' should be 'Speech'

The ruby example said 'text to speach service in **php**.', but should be 'ext to speach service in **ruby**.'